### PR TITLE
Add separate task for exporting a notebook and accept arbitrary execute_kwargs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
+- Added a new task `export_notebook` to export a notebook using nbconvert, this was stripped from the `execute_notebook` task to allow for more flexibility in the future.
 
 ### Changed
+- `execute_notebook` now accepts arbitrary `execute_kwargs` instead of `export_kwargs`
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -46,10 +46,11 @@ from prefect_jupyter import notebook
 
 @flow
 def example_execute_notebook():
-    body = notebook.execute_notebook(
+    nb = notebook.execute_notebook(
         "test_notebook.ipynb",
         parameters={"num": 5}
     )
+    body = notebook.export_notebook(nb)
     output_path = "executed_notebook.ipynb"
     with open(output_path, "w") as f:
         f.write(body)

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -8,9 +8,12 @@ from prefect_jupyter import notebook
 
 def test_execute_notebook():
     file_path = Path(__file__).parent.resolve()
-    body = notebook.execute_notebook.fn(
+    nb = notebook.execute_notebook.fn(
         file_path / "test_notebook.ipynb", parameters={"num": 5}
     )
+    assert len(nb.cells) == 3
+
+    body = notebook.export_notebook.fn(nb)
     contents = json.loads(body)
     assert len(contents["cells"]) == 3  # generates a parameter cell
 


### PR DESCRIPTION


<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Closes

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->
Docs screenshot:
<img width="1449" alt="Screen Shot 2022-12-06 at 7 32 36 PM" src="https://user-images.githubusercontent.com/39169550/206081523-61cfcbe9-24b2-4162-b8b8-400846c724cb.png">


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-jupyter/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [x] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-jupyter/blob/main/CHANGELOG.md)
